### PR TITLE
Added create_board to examples

### DIFF
--- a/examples.py
+++ b/examples.py
@@ -180,6 +180,7 @@ def load_pin_by_id(pin_id=''):
 # pin(board_id=board_id, section_id=section_id)
 
 
+# Careful with category names. They have different names than as shown on Pinterest
 def create_board(name='',
                description='',
                category='other',

--- a/examples.py
+++ b/examples.py
@@ -180,6 +180,15 @@ def load_pin_by_id(pin_id=''):
 # pin(board_id=board_id, section_id=section_id)
 
 
+def create_board(name='',
+               description='',
+               category='other',
+               privacy='public',
+               layout='default'):
+    return pinterest.create_board(name=name, description=description, category=category,
+                                privacy=privacy, layout=layout)
+
+
 def create_board_section(board_id='', section_name=''):
     return pinterest.create_board_section(board_id=board_id, section_name=section_name)
 


### PR DESCRIPTION
Made issue #38, and then I did a bit of investigation into the py3-pinterest library code. Turns out the Create_Board function was there, but wasn't brought to light in the examples.

Added the create_board function to examples.py. Tested and is working properly.